### PR TITLE
Little chores

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,9 +10,14 @@ option(EP_UT "Build and run unit tests" ON)
 option(SKIP_DEPS "Skip dependency fetch step" OFF)
 
 include(cmake/compile_flags.cmake)
-include(cmake/vcpkg.cmake)
 
 if (NOT SKIP_DEPS)
+  include(cmake/vcpkg.cmake)
+
+  # in case qt builds from source once again without:
+  #   /usr/bin/ld: fcxml.c:(...):      undefined reference to `XML_...'
+  #   /usr/bin/ld: fcfreetype.c:(...): undefined reference to `FT_....'
+  #
   # remove qtdeclarative once migrated to widgets. qtbase is self sufficient
   # for widget-based apps
   add_vcpkg_deps("gtest" "qtbase" "qtdeclarative")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,8 @@ include(cmake/compile_flags.cmake)
 include(cmake/vcpkg.cmake)
 
 if (NOT SKIP_DEPS)
+  # remove qtdeclarative once migrated to widgets. qtbase is self sufficient
+  # for widget-based apps
   add_vcpkg_deps("gtest" "qtbase" "qtdeclarative")
 endif()
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ version _older_ than 1.6.
 
 For Debian based distros:
 ```
-sudo apt install libxkbcommon0=1.5.0-1
+sudo apt install libxkbcommon-dev=1.5.0-1
 ```
 
 For Arch based distros:

--- a/cmake/vcpkg.cmake
+++ b/cmake/vcpkg.cmake
@@ -18,11 +18,11 @@ endif()
 
 set(VCPKG_DEPS_PREFIX ${VCPKG_ROOT}/installed)
 if (WIN32)
-  #list(APPEND CMAKE_MODULE_PATH ";${VCPKG_DEPS_PREFIX}/x64-windows")
   list(APPEND CMAKE_PREFIX_PATH ";${VCPKG_DEPS_PREFIX}/x64-windows")
 elseif(LINUX)
-  #list(APPEND CMAKE_MODULE_PATH ";${VCPKG_DEPS_PREFIX}/x64-linux")
   list(APPEND CMAKE_PREFIX_PATH ";${VCPKG_DEPS_PREFIX}/x64-linux")
+elseif(APPLE)
+  list(APPEND CMAKE_PREFIX_PATH ";${VCPKG_DEPS_PREFIX}/x64-osx")
 endif()
 
 function(add_vcpkg_deps)


### PR DESCRIPTION
Fix typo in package name
Description mentioned libxkbcommon0 instead of libxkbcommon-dev as a
dependency to build Qt from source.

Signed-off-by: Vasilii Generalov <vasilii.generalov@yandex.ru>

---

Update and clean-up vcpkg.cmake
The vcpkg.cmake module is updated to work on macOS

Signed-off-by: Vasilii Generalov <vasilii.generalov@yandex.ru>

---

Leave a comment regarding dependencies
qtbase is self sufficient for widget-based Qt apps, this commit adds a
comment about that in the root CMakeLists.txt

Signed-off-by: Vasilii Generalov <vasilii.generalov@yandex.ru>

---

Do not modify cmake path unconditionally
Cmake prefix path used to be modified no matter dependency step was
skipped or not. Vcpkg cmake module is sourced conditionally in this
commit, to be able to fallback to system libraries instead

Signed-off-by: Vasilii Generalov <vasilii.generalov@yandex.ru>